### PR TITLE
Adding some debug

### DIFF
--- a/src/main/java/com/github/orgs/kotobaminers/virtualryuugaku/virtualryuugaku/Events.java
+++ b/src/main/java/com/github/orgs/kotobaminers/virtualryuugaku/virtualryuugaku/Events.java
@@ -62,6 +62,8 @@ public class Events implements Listener {
 		try {
 			CommentHandler.printCommentNew(player);
 		} catch(Exception e) {
+			// TOOD: This never supposed to happened.
+			UtilitiesProgramming.printDebugMessage("ERROR: ", e);
 		}
 	}
 


### PR DESCRIPTION
before f126e2ac509e9bd771150bfbfea968b5d5329a78 plugin made critical failure. This debug will show reason if that same problem occurs
